### PR TITLE
add-crlf-option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ When using fastplate you can pass the listed arguments / options down below.
 | -var {FilePath} | The optional variable file path for unscoped variables.                                        |
 | -no-stats       | Disable stats printing.                                                                        |
 | -indent         | Enable indention. Spaces / tabs in front of `import` statements will be used for the partials. |
+| -crlf           | Split and join contents by CRLF (\r\n) instead of LF (\n).                                     |
 
 ### Example
 1. Complete template "tempalte.json":  

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/xiroxasx/fastplate
 go 1.19
 
 require (
-	github.com/rs/zerolog v1.28.0
+	github.com/rs/zerolog v1.29.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/text v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
-github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
+github.com/rs/zerolog v1.29.0 h1:Zes4hju04hjbvkVkOhdl2HpZa+0PmVwigmo8XoORE5w=
+github.com/rs/zerolog v1.29.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/interpreter/foreach.go
+++ b/interpreter/foreach.go
@@ -38,7 +38,7 @@ func (i *Interpreter) evaluateForeach(file string, out io.Writer) (err error) {
 			if err != nil {
 				return
 			}
-			_, err = out.Write(append(mod, '\n'))
+			_, err = out.Write(append(mod, i.splitChars...))
 			if err != nil {
 				return
 			}

--- a/interpreter/foreach.go
+++ b/interpreter/foreach.go
@@ -38,7 +38,7 @@ func (i *Interpreter) evaluateForeach(file string, out io.Writer) (err error) {
 			if err != nil {
 				return
 			}
-			_, err = out.Write(append(mod, i.splitChars...))
+			_, err = out.Write(append(mod, i.lineEnding...))
 			if err != nil {
 				return
 			}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -17,9 +17,10 @@ import (
 const varFileName = "fastplate.var"
 
 type Interpreter struct {
-	opts     *Options
-	prefixes []string
-	state    state
+	opts       *Options
+	prefixes   []string
+	state      state
+	splitChars []byte
 }
 
 type Options struct {
@@ -27,6 +28,7 @@ type Options struct {
 	OutPath      string
 	VarFilePaths VarFilePaths
 	Indent       bool
+	UseCRLF      bool
 	NoStats      bool
 }
 
@@ -67,8 +69,9 @@ func defaultImportPrefixes() []string {
 
 func New(opts *Options) (i Interpreter) {
 	i = Interpreter{
-		opts:     opts,
-		prefixes: defaultImportPrefixes(),
+		opts:       opts,
+		prefixes:   defaultImportPrefixes(),
+		splitChars: []byte("\n"),
 		state: state{
 			ignoreIndex:  map[string]int8{},
 			scopedVars:   map[string][]variable{},
@@ -76,6 +79,10 @@ func New(opts *Options) (i Interpreter) {
 			foreach:      map[string]foreach{},
 			Mutex:        &sync.Mutex{},
 		},
+	}
+
+	if opts.UseCRLF {
+		i.splitChars = []byte("\r\n")
 	}
 
 	// Look in the current working directory.
@@ -97,7 +104,7 @@ func New(opts *Options) (i Interpreter) {
 		if err != nil {
 			log.Fatal().Err(err).Str("path", vf).Msg("unable to read global variable file")
 		}
-		lines := bytes.Split(cont, []byte{'\n'})
+		lines := bytes.Split(cont, i.splitChars)
 		for _, l := range lines {
 			split := bytes.Split(i.CutPrefix(l), []byte{' '})
 			if string(split[0]) != commandVar {
@@ -112,7 +119,7 @@ func New(opts *Options) (i Interpreter) {
 }
 
 func (i *Interpreter) TrimLine(b, prefix []byte) []byte {
-	return bytes.Trim(bytes.TrimPrefix(b, prefix), "\n ")
+	return bytes.Trim(bytes.TrimPrefix(b, prefix), string(i.splitChars)+" ")
 }
 
 func (i *Interpreter) CutPrefix(b []byte) (ret []byte) {
@@ -142,7 +149,7 @@ func (i *Interpreter) Start() (err error) {
 	}
 
 	if !i.opts.NoStats {
-		fmt.Printf("Execution took %v\n", el)
+		fmt.Println("Execution took", el)
 	}
 	return
 }
@@ -221,12 +228,12 @@ func (i *Interpreter) runFileMode() (err error) {
 func (i *Interpreter) interpretFile(filePath string, indent []byte, out io.Writer) (err error) {
 	cont, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Printf("warn: unable to read file %s: %v\n", filePath, err)
+		log.Warn().Err(err).Str("file", filePath).Msg("unable to read file")
 		return
 	}
 
 	// Append indention to all linebreaks, prepend to the first line.
-	cutSet := []byte{'\n'}
+	cutSet := i.splitChars
 	if len(indent) > 0 {
 		cont = bytes.ReplaceAll(cont, cutSet, append(cutSet, indent...))
 		cont = append(indent, cont...)

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -20,7 +20,7 @@ type Interpreter struct {
 	opts       *Options
 	prefixes   []string
 	state      state
-	splitChars []byte
+	lineEnding []byte
 }
 
 type Options struct {
@@ -71,7 +71,7 @@ func New(opts *Options) (i Interpreter) {
 	i = Interpreter{
 		opts:       opts,
 		prefixes:   defaultImportPrefixes(),
-		splitChars: []byte("\n"),
+		lineEnding: []byte("\n"),
 		state: state{
 			ignoreIndex:  map[string]int8{},
 			scopedVars:   map[string][]variable{},
@@ -82,7 +82,7 @@ func New(opts *Options) (i Interpreter) {
 	}
 
 	if opts.UseCRLF {
-		i.splitChars = []byte("\r\n")
+		i.lineEnding = []byte("\r\n")
 	}
 
 	// Look in the current working directory.
@@ -104,7 +104,7 @@ func New(opts *Options) (i Interpreter) {
 		if err != nil {
 			log.Fatal().Err(err).Str("path", vf).Msg("unable to read global variable file")
 		}
-		lines := bytes.Split(cont, i.splitChars)
+		lines := bytes.Split(cont, i.lineEnding)
 		for _, l := range lines {
 			split := bytes.Split(i.CutPrefix(l), []byte{' '})
 			if string(split[0]) != commandVar {
@@ -119,7 +119,7 @@ func New(opts *Options) (i Interpreter) {
 }
 
 func (i *Interpreter) TrimLine(b, prefix []byte) []byte {
-	return bytes.Trim(bytes.TrimPrefix(b, prefix), string(i.splitChars)+" ")
+	return bytes.Trim(bytes.TrimPrefix(b, prefix), string(i.lineEnding)+" ")
 }
 
 func (i *Interpreter) CutPrefix(b []byte) (ret []byte) {
@@ -233,7 +233,7 @@ func (i *Interpreter) interpretFile(filePath string, indent []byte, out io.Write
 	}
 
 	// Append indention to all linebreaks, prepend to the first line.
-	cutSet := i.splitChars
+	cutSet := i.lineEnding
 	if len(indent) > 0 {
 		cont = bytes.ReplaceAll(cont, cutSet, append(cutSet, indent...))
 		cont = append(indent, cont...)

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func parseFlags() (a importer.Options) {
 	flag.BoolVar(&a.NoStats, "no-stats", false, "do not print stats at the end of the execution")
 	flag.StringVar(&a.InPath, "in", "", "the root path")
 	flag.StringVar(&a.OutPath, "out", "", "the output path. If not used, in will be overwritten")
+	flag.BoolVar(&a.UseCRLF, "crlf", false, "whether to split lines by \\r\\n or \\n")
 	flag.Var(&a.VarFilePaths, "var", "the optional var file path.")
 	flag.Parse()
 	return
@@ -36,11 +37,11 @@ func main() {
 	if opts.OutPath == "" {
 		r := bufio.NewReader(os.Stdin)
 		fmt.Printf("Are you sure that you want to overwrite %s? [y/N] ", opts.InPath)
-		b, err := r.ReadBytes('\n')
+		b, err := r.ReadByte()
 		if err != nil {
 			log.Fatal().Err(err).Msg("unable to read input")
 		}
-		if bytes.ToLower([]byte{b[0]})[0] != 'y' {
+		if bytes.ToLower([]byte{b})[0] != 'y' {
 			log.Fatal().Err(err).Msg("canceled")
 		}
 		opts.OutPath = opts.InPath


### PR DESCRIPTION
Adds an option (`-crlf`) to use CRLF instead of LF (default) for reading and writing files.